### PR TITLE
Anvil Name NPE fix

### DIFF
--- a/src/main/java/openmods/utils/VanillaAnvilLogic.java
+++ b/src/main/java/openmods/utils/VanillaAnvilLogic.java
@@ -24,7 +24,7 @@ public class VanillaAnvilLogic {
 		this.materialCost = -1;
 		this.outputStack = ItemStack.EMPTY;
 
-		final String repairedItemName = itemName.orNull();
+		final String repairedItemName = itemName.or("");
 
 		// adapted/copied from ContainerRepair.updateRepairOutput
 		this.maximumCost = 1;


### PR DESCRIPTION
changes in this PR:
- make anvil name empty string instead of null

this changes it to match vanilla behavior. because this fires an `AnvilUpdateEvent`, this is required - some mods may check the `name` based on it being nonnull, which it always is in vanilla. in particular, the Quark [DyeItemNames](https://github.com/VazkiiMods/Quark/blob/1.12/src/main/java/vazkii/quark/vanity/feature/DyeItemNames.java#L72) feature can cause crashes such as [this one in DJ2](https://github.com/Divine-Journey-2/Divine-Journey-2/issues/913).